### PR TITLE
Fix #1 - Handle older versions of Facter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Fixed
 - Made repo source file match PPA naming scheme
+- Support for older Facter versions (<3.0.0)
 
 ## [0.1.1] - 2017-09-12
 ### Added

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,15 +51,26 @@ class flatpak (
 ){
   include ::apt
 
+  # If Facter is at least 3.0.0
+  if versioncmp($::facterversion, '3.0.0') >= 0 {
+    $dist_codename = $::os['distro']['codename']
+  } elsif versioncmp($::facterversion, '2.2.0') >= 0 {
+    # Version is at least 2.2.0
+    $dist_codename = $::os['lsb']['distcodename']
+  } else {
+    # REALLY old version, use legacy fact
+    $dist_codename = $::lsbdistcodename
+  }
+
   if $repo_file_name {
     $repo_name = $repo_file_name
   } else {
-    $repo_name = "alexlarsson-ubuntu-flatpak-${::os['distro']['codename']}"
+    $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
   }
 
   apt::source { $repo_name:
     location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
-    release  => $::os['distro']['codename'],
+    release  => $dist_codename,
     repos    => 'main',
     key      => {
       id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',


### PR DESCRIPTION
Facter >=2.2 <3.0 use a different key for the distro code name , so for
those versions, we should use the proper name.