### PR TITLE
Fix #2 - Conform to PPA naming standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Made repo source file match PPA naming scheme
+
 ## [0.1.1] - 2017-09-12
 ### Added
 - Changelog
@@ -20,5 +24,6 @@ Initial release
 - Add/Remove Flatpak remotes
 - Install/uninstall Flatpak apps
 
+[Unreleased]: https://github.com/brwyatt/puppet-flatpak/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/brwyatt/puppet-flatpak/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/brwyatt/puppet-flatpak/compare/ff5cbee...v0.1.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,10 +47,17 @@
 
 class flatpak (
   String $package_ensure = 'installed',
+  Optional[String] $repo_file_name = undef,
 ){
   include ::apt
 
-  apt::source { 'flatpak':
+  if $repo_file_name {
+    $repo_name = $repo_file_name
+  } else {
+    $repo_name = "alexlarsson-ubuntu-flatpak-${::os['distro']['codename']}"
+  }
+
+  apt::source { $repo_name:
     location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
     release  => $::os['distro']['codename'],
     repos    => 'main',
@@ -66,7 +73,7 @@ class flatpak (
 
   Flatpak_remote <| |> -> Flatpak <| |>
 
-  Apt::Source['flatpak'] -> Package['flatpak']
+  Apt::Source[$repo_name] -> Package['flatpak']
 }
 
 # vim: ts=2 sts=2 sw=2 expandtab


### PR DESCRIPTION
This helps avoid duplicated repos if Flatpak was previously added to a
system.