### PR TITLE
Add new parameter version of provider flatpak (multiple branches).

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Parameters:
 * `ensure`: If the package should be `present` (or `installed`) or `absent` (or
   `uninstalled`)
 * `ref`: (namevar) The name of the package reference to be installed (or removed)
+* `version`: The name of the package version to be installed
 * `remote`: The name of the remote repo to install the package from
 
 #### `flatpak_remote`

--- a/lib/puppet/provider/flatpak/flatpak.rb
+++ b/lib/puppet/provider/flatpak/flatpak.rb
@@ -23,7 +23,8 @@ Puppet::Type.type(:flatpak).provide(:flatpak) do
   commands :flatpak => '/usr/bin/flatpak'
 
   def create
-    args = [ "install", "--assumeyes", resource[:remote], resource[:ref] ]
+    name = resource[:version].nil? ? resource[:ref] : "#{resource[:ref]}//#{resource[:version]}"
+    args = [ "install", "--assumeyes", resource[:remote], name ]
     flatpak(args)
   end
 

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -51,6 +51,11 @@ Puppet::Type.newtype(:flatpak) do
     newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
   end
 
+  newparam(:version) do
+    desc 'Version of package to install'
+    newvalues(/^(\d+(?:\.\d+)+|master)$/)
+  end
+
   newparam(:remote) do
     desc 'Name of the remote repo to install from'
   end


### PR DESCRIPTION
I try install linphone:
```
  flatpak_remote { 'linphone':
    ensure => present,
    location => 'https://linphone.org/flatpak/bc.flatpakrepo',
    from => true,
  } ->
  flatpak { 'linphone':
    ensure => present,
    ref => 'com.belledonnecommunications.linphone',
    remote => 'linphone',
  }
```
I get an error:
```
Error: Execution of '/usr/bin/flatpak install --assumeyes linphone com.belledonnecommunications.linphone' returned 1: error: Multiple branches available for com.belledonnecommunications.linphone, you must specify one of: com.belledonnecommunications.linphone//4.0, com.belledonnecommunications.linphone//4.1.1, com.belledonnecommunications.linphone//master
Error: /Stage[main]/Profiles::Pc::Stuff/Flatpak[linphone]/ensure: change from absent to present failed: Execution of '/usr/bin/flatpak install --assumeyes linphone com.belledonnecommunications.linphone' returned 1: error: Multiple branches available for com.belledonnecommunications.linphone, you must specify one of: com.belledonnecommunications.linphone//4.0, com.belledonnecommunications.linphone//4.1.1, com.belledonnecommunications.linphone//master
```
Working code with new parameter version: 
```
  flatpak { 'linphone':
    ensure => present,
    ref => 'com.belledonnecommunications.linphone',
    version => '4.1.1',
    remote => 'linphone',
  }
```
Puppet report:
```
Notice: /Stage[main]/Profiles::Pc::Stuff/Flatpak[linphone]/ensure: created
```
