### PR TITLE
Implement #6 - Extend `flatpak` Type with `arch` and `branch` Parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New parameters to `flatpak` type: `name`, `arch`, `branch`
+
+### Changed
+- `flatpak` type's namevar is now `name` instead of `ref`. Behavior and
+  expected values remains the same as before.
+
 ### Fixed
 - Made repo source file match PPA naming scheme
 - Support for older Facter versions (<3.0.0)
+- `flatpak` type now accepts a full Identifier Triple for `ref` parameter
 
 ## [0.1.1] - 2017-09-12
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - `flatpak` type's namevar is now `name` instead of `ref`. Behavior and
   expected values remains the same as before.
 - The `remote` parameter on the `flatpak` type is now explicitly required
+  when installing a package.
 
 ### Fixed
 - Made repo source file match PPA naming scheme

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - `flatpak` type's namevar is now `name` instead of `ref`. Behavior and
   expected values remains the same as before.
+- The `remote` parameter on the `flatpak` type is now explicitly required
 
 ### Fixed
 - Made repo source file match PPA naming scheme

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Parameters:
 * `ensure`: If the package should be `present` (or `installed`) or `absent` (or
   `uninstalled`)
 * `ref`: (namevar) The name of the package reference to be installed (or removed)
+* `version`: The name of the package version to be installed
 * `remote`: The name of the remote repo to install the package from
 
 #### `flatpak_remote`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ Parameters:
 * `ref`: The package ref to install. This can be any valid pakcage ref, from
   simply the package name up to a full Identifier Triple ("name/arch/branch").
   Cannot be used if `branch` or `arch` are defined.
-* `remote`: (required) The name of the remote repo to install the package from
+* `remote`: The name of the remote repo to install the package from. Required
+  if `ensure` is "installed" or "present".
 
 If defined, this type will install the package identified in the `ref`
 parameter. Otherwise, it will attempt to generate an Identifier Triple from

--- a/README.md
+++ b/README.md
@@ -97,9 +97,21 @@ This type installs (or uninstalls) Flatpak apps.
 Parameters:
 * `ensure`: If the package should be `present` (or `installed`) or `absent` (or
   `uninstalled`)
-* `ref`: (namevar) The name of the package reference to be installed (or removed)
-* `version`: The name of the package version to be installed
+* `arch`: The package architecture to be installed. Cannot be used if `ref` is
+  defined.
+* `branch`: The package branch to be installed. Cannot be used if `ref` is
+  defined.
+* `name`: (namevar) The name of the package to be installed (or removed)
+* `ref`: The package ref to install. This can be any valid pakcage ref, from
+  simply the package name up to a full Identifier Triple ("name/arch/branch").
+  Cannot be used if `branch` or `arch` are defined.
 * `remote`: The name of the remote repo to install the package from
+
+If defined, this type will install the package identified in the `ref`
+parameter. Otherwise, it will attempt to generate an Identifier Triple from
+the values of `name`/`arch`/`branch`. If no parameters are explicitly defined,
+this will result in attempting to install the package with the resource's name
+and the remote's default architecture and branch.
 
 #### `flatpak_remote`
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Parameters:
 * `ref`: The package ref to install. This can be any valid pakcage ref, from
   simply the package name up to a full Identifier Triple ("name/arch/branch").
   Cannot be used if `branch` or `arch` are defined.
-* `remote`: The name of the remote repo to install the package from
+* `remote`: (required) The name of the remote repo to install the package from
 
 If defined, this type will install the package identified in the `ref`
 parameter. Otherwise, it will attempt to generate an Identifier Triple from

--- a/lib/puppet/provider/flatpak/flatpak.rb
+++ b/lib/puppet/provider/flatpak/flatpak.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:flatpak).provide(:flatpak) do
   commands :flatpak => '/usr/bin/flatpak'
 
   def create
-    name = resource[:version].nil? ? resource[:ref] : "#{resource[:ref]}//#{resource[:version]}"
+    name = resource[:branch].nil? ? resource[:ref] : "#{resource[:ref]}//#{resource[:branch]}"
     args = [ "install", "--assumeyes", resource[:remote], name ]
     flatpak(args)
   end

--- a/lib/puppet/provider/flatpak/flatpak.rb
+++ b/lib/puppet/provider/flatpak/flatpak.rb
@@ -22,18 +22,32 @@ Puppet::Type.type(:flatpak).provide(:flatpak) do
 
   commands :flatpak => '/usr/bin/flatpak'
 
+  def resolve_ref(resource)
+    if resource[:ref]
+      ref = resource[:ref]
+    else
+      arch = resource[:arch].nil? ? "/" : "/#{resource[:arch]}"
+      branch = resource[:branch].nil? ? "/" : "/#{resource[:branch]}"
+      ref = resource[:name] + arch + branch
+    end
+
+    return ref
+  end
+
   def create
-    name = resource[:branch].nil? ? resource[:ref] : "#{resource[:ref]}//#{resource[:branch]}"
-    args = [ "install", "--assumeyes", resource[:remote], name ]
+    ref = resolve_ref(resource)
+    args = [ "install", "--assumeyes", resource[:remote], ref ]
     flatpak(args)
   end
 
   def destroy
-    flatpak "uninstall", resource[:ref]
+    ref = resolve_ref(resource)
+    flatpak "uninstall", ref
   end
 
   def exists?
-    r = execute(["#{command(:flatpak)} info #{resource[:ref]}"], :failonfail => false)
+    ref = resolve_ref(resource)
+    r = execute(["#{command(:flatpak)} info #{ref}"], :failonfail => false)
     if r.exitstatus == 0
       true
     else

--- a/lib/puppet/provider/flatpak/flatpak.rb
+++ b/lib/puppet/provider/flatpak/flatpak.rb
@@ -23,7 +23,8 @@ Puppet::Type.type(:flatpak).provide(:flatpak) do
   commands :flatpak => '/usr/bin/flatpak'
 
   def create
-    args = [ "install", "--assumeyes", resource[:remote], resource[:ref] ]
+    name = resource[:version].nil? ? resource[:ref] : "#{resource[:ref]}//#{resource[:version]}"
+    args = [ "install", "--assumeyes", resource[:remote], name ]
     flatpak(args)
   end
 

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -51,8 +51,8 @@ Puppet::Type.newtype(:flatpak) do
     newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
   end
 
-  newparam(:version) do
-    desc 'Version of package to install'
+  newparam(:branch) do
+    desc 'Branch of package to install'
     newvalues(/^(\d+(?:\.\d+)+|master)$/)
   end
 

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -51,6 +51,11 @@ Puppet::Type.newtype(:flatpak) do
     newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
   end
 
+  newparam(:version) do
+    desc 'Version of package to install'
+    newvalues(/^(\d+(?:\.\d+)+|master)$/)
+  end
+
   newparam(:remote) do
     desc 'Name of the remote repo to install from'
   end

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -55,8 +55,9 @@ Puppet::Type.newtype(:flatpak) do
              'information.'].join(' '))
     end
 
-    if self[:remote].nil?
-      raise('Parameter `remote` must be defined.')
+    if self[:remote].nil? && [:present, :installed].include?(self[:ensure])
+      raise(['Parameter `remote` must be defined if `ensure` is "present" or',
+             '"installed".'].join(' '))
     end
   end
 
@@ -85,7 +86,7 @@ Puppet::Type.newtype(:flatpak) do
   end
 
   newparam(:remote) do
-    desc 'Name of the remote repo to install from. (required)'
+    desc 'Name of the remote repo to install from.'
     newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
   end
 

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -44,11 +44,28 @@ Puppet::Type.newtype(:flatpak) do
   end
 
   validate do
+    if self[:ref] && (self[:arch] || self[:branch])
+      raise(['Use of `ref` with `arch` and `branch` is ambiguous. Package arch',
+             'and branch should be defined in `ref` as an Identifier Triple if',
+             '`ref` is defined, or package name should be defined with `name`',
+             'or namevar instead of with `ref`. See README.md for more',
+             'information.'].join(' '))
+    end
   end
 
-  newparam(:ref, :namevar => true) do
-    desc 'Package reference to install'
+  newparam(:name, :namevar => true) do
+    desc 'Package name to install'
     newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
+  end
+
+  newparam(:ref) do
+    desc 'Package reference to install. Incompatable with `arch` and `branch`'
+    newvalues(/\A[a-zA-Z0-9.\-_]+(?:\/[a-zA-Z0-9.\-_]*){0,2}\Z/)
+  end
+
+  newparam(:arch) do
+    desc 'Architecture of package to install'
+    newvalues(:aarch64, :arm, :i386, :x86_64)
   end
 
   newparam(:branch) do

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -53,7 +53,7 @@ Puppet::Type.newtype(:flatpak) do
 
   newparam(:branch) do
     desc 'Branch of package to install'
-    newvalues(/^(\d+(?:\.\d+)+|master)$/)
+    newvalues(/\A[a-zA-Z0-9.\-_]+\Z/)
   end
 
   newparam(:remote) do

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -54,6 +54,10 @@ Puppet::Type.newtype(:flatpak) do
              'or namevar instead of with `ref`. See README.md for more',
              'information.'].join(' '))
     end
+
+    if self[:remote].nil?
+      raise('Parameter `remote` must be defined.')
+    end
   end
 
   newparam(:name, :namevar => true) do
@@ -81,7 +85,8 @@ Puppet::Type.newtype(:flatpak) do
   end
 
   newparam(:remote) do
-    desc 'Name of the remote repo to install from.'
+    desc 'Name of the remote repo to install from. (required)'
+    newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
   end
 
 end

--- a/lib/puppet/type/flatpak.rb
+++ b/lib/puppet/type/flatpak.rb
@@ -23,6 +23,9 @@ Puppet::Type.newtype(:flatpak) do
   @doc = <<-EOS
     This type provides Puppet with the capabilities to manage flatpak apps.
     flatpak { 'org.gnome.Platform':
+      ensure => installed,
+      arch   => 'x86_64',
+      branch => '3.2',
       remote => 'gnome',
     }
   EOS
@@ -54,27 +57,31 @@ Puppet::Type.newtype(:flatpak) do
   end
 
   newparam(:name, :namevar => true) do
-    desc 'Package name to install'
+    desc 'Name of package to install. (namevar)'
     newvalues(/\A[a-zA-Z0-9.\-_]*\Z/)
   end
 
   newparam(:ref) do
-    desc 'Package reference to install. Incompatable with `arch` and `branch`'
+    desc <<-EOS
+      Reference of package to install. May be full Identifier Triple.
+      Incompatable with `arch` and `branch`.
+    EOS
+
     newvalues(/\A[a-zA-Z0-9.\-_]+(?:\/[a-zA-Z0-9.\-_]*){0,2}\Z/)
   end
 
   newparam(:arch) do
-    desc 'Architecture of package to install'
+    desc 'Architecture of package to install. Incompatable with `ref`.'
     newvalues(:aarch64, :arm, :i386, :x86_64)
   end
 
   newparam(:branch) do
-    desc 'Branch of package to install'
+    desc 'Branch of package to install, Incompatable with `ref`.'
     newvalues(/\A[a-zA-Z0-9.\-_]+\Z/)
   end
 
   newparam(:remote) do
-    desc 'Name of the remote repo to install from'
+    desc 'Name of the remote repo to install from.'
   end
 
 end


### PR DESCRIPTION
This expands upon the changes offered in #5 to additionally include an `arch` parameter and rename `version` to `branch` to better match the naming in the Flatpak documentation.

Also includes fixes to allow `ref` to accept a full Identifier Triple, and explicitly require `remote` to be defined as install will fail otherwise.