### PR TITLE
Add RedHat OS family support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,10 @@
 
 ## Description
 
-This module installs Flatpak from the developer's PPA on Launchpad and offers
-two defined types, one for adding/removing Remotes and another for installing/
+This module installs Flatpak. 
+* On Debian family from the developer's PPA Debian on Launchpad.
+* On Redhat family the OS flatpak is used.
+The module offers two defined types, one for adding/removing Remotes and another for installing/
 removing Flatpak applications.
 
 This module was created to allow for managing/installing Flatpak-based
@@ -39,15 +41,15 @@ Flatpak's ability to be one-size-fits all.
 
 ### What flatpak affects
 
-This module adds the Flatpak PPA on Launchpad to the system's repository and
-installs Flatpak.
+This module adds on Debian the Flatpak PPA on Launchpad to the system's repository. It
+then installs Flatpak.
 
 ### Setup Requirements
 
-Currently, this module only supports Ubuntu, but may work with other Debian-
+Currently, this module supports Ubuntu and RedHat OS family, It may work with other Debian-
 based distributions.
 
-This module requires the `puppetlabs-apt` module in order to manage Apt repos.
+On Ubuntu the module requires the `puppetlabs-apt` module in order to manage Apt repos.
 
 ### Beginning with flatpak
 
@@ -80,7 +82,7 @@ Installs the Flatpak PPA and installs Flatpak
 
 Parameters:
 * `package_ensure`: Ensure value for the Flatpak package. Default: 'installed'
-* `repo_file_name`: Optional name for the repo source file. Defaults to the PPA
+* `repo_file_name`: Optional name for a Unbuntu repo source file. Defaults to the PPA
   naming scheme to avoid duplicate repository files.
 
 #### `flatpak::remotes::gnome`
@@ -138,10 +140,9 @@ Implements the `flatpak_remote` type. Default provider.
 
 ## Limitations
 
-Currently, this module can only install on Debian-based systems and has not been
-tested on distributions other than Ubuntu 16.04. It may or may not work on other
-Debian-based distributions, but makes no claims regarding such. This will not
-currently work at all on RHEL-based systems.
+Currently, this module can only install on Debian-based systems and Redhat based
+systemd it has not been tested on distributions other than Ubuntu 16.04, CentOS 7 and CentOS 8.
+It may or may not work on other Debian-based or Redhat based distributions, but makes no claims regarding such.
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,33 +52,36 @@ class flatpak (
   String $package_ensure = 'installed',
   Optional[String] $repo_file_name = undef,
 ){
-  include ::apt
+  if $facts['os']['family'] == 'Debian' {
+    include ::apt
 
-  # If Facter is at least 3.0.0
-  if versioncmp($::facterversion, '3.0.0') >= 0 {
-    $dist_codename = $::os['distro']['codename']
-  } elsif versioncmp($::facterversion, '2.2.0') >= 0 {
-    # Version is at least 2.2.0
-    $dist_codename = $::os['lsb']['distcodename']
-  } else {
-    # REALLY old version, use legacy fact
-    $dist_codename = $::lsbdistcodename
-  }
+    # If Facter is at least 3.0.0
+    if versioncmp($::facterversion, '3.0.0') >= 0 {
+      $dist_codename = $::os['distro']['codename']
+    } elsif versioncmp($::facterversion, '2.2.0') >= 0 {
+      # Version is at least 2.2.0
+      $dist_codename = $::os['lsb']['distcodename']
+    } else {
+      # REALLY old version, use legacy fact
+      $dist_codename = $::lsbdistcodename
+    }
 
-  if $repo_file_name {
-    $repo_name = $repo_file_name
-  } else {
-    $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
-  }
+    if $repo_file_name {
+      $repo_name = $repo_file_name
+    } else {
+      $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
+    }
 
-  apt::source { $repo_name:
-    location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
-    release  => $dist_codename,
-    repos    => 'main',
-    key      => {
-      id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',
-      server => 'keyserver.ubuntu.com',
-    },
+    apt::source { $repo_name:
+      location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
+      release  => $dist_codename,
+      repos    => 'main',
+      key      => {
+        id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',
+        server => 'keyserver.ubuntu.com',
+      },
+    }
+    Exec['apt_update'] -> Package['flatpak']
   }
 
   package { 'flatpak':
@@ -87,7 +90,6 @@ class flatpak (
 
   Flatpak_remote <| |> -> Flatpak <| |>
 
-  Exec['apt_update'] -> Package['flatpak']
 }
 
 # vim: ts=2 sts=2 sw=2 expandtab

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,18 @@
       "operatingsystemrelease": [
         "16.04"
       ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "8"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/flatpak_spec.rb
+++ b/spec/classes/flatpak_spec.rb
@@ -7,13 +7,23 @@ describe 'flatpak' do
 
       it { is_expected.to compile }
       it { is_expected.to contain_package('flatpak') }
-      it { is_expected.to contain_class('apt') }
-
+      case os_facts[:os]['family']
+      when 'Debian'
+        it { is_expected.to contain_class('apt') }
+      else
+        it { is_expected.not_to contain_class('apt') }
+      end
       context 'with repo_file_name' do
         let(:params) { { 'repo_file_name' => 'TEST' } }
 
-        it { is_expected.to contain_apt__source('TEST') }
-        it { is_expected.to contain_file('/etc/apt/sources.list.d/TEST.list') }
+        case os_facts[:os]['family']
+        when 'Debian'
+          it { is_expected.to contain_apt__source('TEST') }
+          it { is_expected.to contain_file('/etc/apt/sources.list.d/TEST.list') }
+        else
+          it { is_expected.not_to contain_apt__source('TEST') }
+          it { is_expected.not_to contain_file('/etc/apt/sources.list.d/TEST.list') }
+        end
       end
     end
   end


### PR DESCRIPTION
Only real change is skip all the apt repository stuff. flatpak
is part of OS in RHEL7 and 8.