### PR TITLE
make repository management optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 
 ## Description
 
-This module installs Flatpak from the developer's PPA on Launchpad and offers
-two defined types, one for adding/removing Remotes and another for installing/
-removing Flatpak applications.
+This module (optionnally) installs Flatpak from the developer's PPA on
+Launchpad and offers two defined types, one for adding/removing
+Remotes and another for installing/ removing Flatpak applications.
 
 This module was created to allow for managing/installing Flatpak-based
 application distributions, as some developers have started to move away from
@@ -39,15 +39,16 @@ Flatpak's ability to be one-size-fits all.
 
 ### What flatpak affects
 
-This module adds the Flatpak PPA on Launchpad to the system's repository and
-installs Flatpak.
+This module adds the Flatpak PPA on Launchpad to the system's
+repository (if `manage_repo` is true) and installs Flatpak.
 
 ### Setup Requirements
 
 Currently, this module only supports Ubuntu, but may work with other Debian-
 based distributions.
 
-This module requires the `puppetlabs-apt` module in order to manage Apt repos.
+This module requires the `puppetlabs-apt` module in order to manage
+Apt repos (if `manage_repo` is true).
 
 ### Beginning with flatpak
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,8 +57,6 @@ class flatpak (
   Boolean $manage_repo = true,
   Optional[String] $repo_file_name = undef,
 ){
-  include ::apt
-
   # If Facter is at least 3.0.0
   if versioncmp($::facterversion, '3.0.0') >= 0 {
     $dist_codename = $::os['distro']['codename']
@@ -71,6 +69,8 @@ class flatpak (
   }
 
   if $manage_repo {
+    include ::apt
+
     if $repo_file_name {
       $repo_name = $repo_file_name
     } else {
@@ -86,6 +86,8 @@ class flatpak (
         server => 'keyserver.ubuntu.com',
       },
     }
+
+    Exec['apt_update'] -> Package['flatpak']
   }
 
   package { 'flatpak':
@@ -93,8 +95,6 @@ class flatpak (
   }
 
   Flatpak_remote <| |> -> Flatpak <| |>
-
-  Exec['apt_update'] -> Package['flatpak']
 }
 
 # vim: ts=2 sts=2 sw=2 expandtab

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,10 @@
 # Ensure value for the Flatpack package. Should be 'installed', 'latest', or a
 # version. Defaults to 'installed'.
 #
+# * `manage_repo`
+# Wether we should manage the apt repo or assume that flatpak is
+# available from packaging. Defaults to 'true'.
+#
 # * `repo_file_name`
 # Optional name for the repo source file. Defaults to the PPA naming scheme to
 # avoid duplicate repository files.
@@ -50,6 +54,7 @@
 
 class flatpak (
   String $package_ensure = 'installed',
+  Boolean $manage_repo = true,
   Optional[String] $repo_file_name = undef,
 ){
   include ::apt
@@ -65,20 +70,22 @@ class flatpak (
     $dist_codename = $::lsbdistcodename
   }
 
-  if $repo_file_name {
-    $repo_name = $repo_file_name
-  } else {
-    $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
-  }
+  if $manage_repo {
+    if $repo_file_name {
+      $repo_name = $repo_file_name
+    } else {
+      $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
+    }
 
-  apt::source { $repo_name:
-    location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
-    release  => $dist_codename,
-    repos    => 'main',
-    key      => {
-      id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',
-      server => 'keyserver.ubuntu.com',
-    },
+    apt::source { $repo_name:
+      location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
+      release  => $dist_codename,
+      repos    => 'main',
+      key      => {
+        id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',
+        server => 'keyserver.ubuntu.com',
+      },
+    }
   }
 
   package { 'flatpak':

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
This makes it possible to use this on Debian without using any PPA, as flatpak is provided there and it works fine. I also suspect it will make it easier to add support for other operating systems, like RedHat, and is simpler than #8.

I also update stdlib while I'm here so that this works with the latest.