### PR TITLE
Optional apt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2020-10-10
+Feature/support release
+### Added
+- `manage_repo` parameter to make repo management optional
+- Add/claim support for RHEL/CentOS
+- Module Hiera for setting defaults conditionally (used by new `manage_repo` parameter)
+
 ## [0.2.5] - 2019-05-24
 ### Added
 - PDK Update
@@ -67,6 +74,7 @@ Initial release
 - Add/Remove Flatpak remotes
 - Install/uninstall Flatpak apps
 
+[0.2.6]: https://github.com/brwyatt/puppet-flatpak/compare/v0.2.5...v0.2.6
 [0.2.5]: https://github.com/brwyatt/puppet-flatpak/compare/v0.2.4...v0.2.5
 [0.2.4]: https://github.com/brwyatt/puppet-flatpak/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/brwyatt/puppet-flatpak/compare/v0.2.2...v0.2.3

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 
 ## Description
 
-This module (optionnally) installs Flatpak from the developer's PPA on
+This module (optionally) installs Flatpak from the developer's PPA on
 Launchpad and offers two defined types, one for adding/removing
-Remotes and another for installing/ removing Flatpak applications.
+Remotes and another for installing/removing Flatpak applications.
 
 This module was created to allow for managing/installing Flatpak-based
 application distributions, as some developers have started to move away from
@@ -39,13 +39,13 @@ Flatpak's ability to be one-size-fits all.
 
 ### What flatpak affects
 
-This module adds the Flatpak PPA on Launchpad to the system's
-repository (if `manage_repo` is true) and installs Flatpak.
+This module (optionally) adds the Flatpak PPA on Launchpad to the system's repository
+(if `manage_repo` is true - default for Debian family) and installs Flatpak.
 
 ### Setup Requirements
 
-Currently, this module only supports Ubuntu, but may work with other Debian-
-based distributions.
+Currently, this module only supports Ubuntu and RedHat, but may work with other Debian-
+based or RedHat-based distributions.
 
 This module requires the `puppetlabs-apt` module in order to manage
 Apt repos (if `manage_repo` is true).

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 
 ## Description
 
-This module installs Flatpak from the developer's PPA on Launchpad and offers
-two defined types, one for adding/removing Remotes and another for installing/
-removing Flatpak applications.
+This module (optionnally) installs Flatpak from the developer's PPA on
+Launchpad and offers two defined types, one for adding/removing
+Remotes and another for installing/ removing Flatpak applications.
 
 This module was created to allow for managing/installing Flatpak-based
 application distributions, as some developers have started to move away from
@@ -39,15 +39,16 @@ Flatpak's ability to be one-size-fits all.
 
 ### What flatpak affects
 
-This module adds the Flatpak PPA on Launchpad to the system's repository and
-installs Flatpak.
+This module adds the Flatpak PPA on Launchpad to the system's
+repository (if `manage_repo` is true) and installs Flatpak.
 
 ### Setup Requirements
 
 Currently, this module only supports Ubuntu, but may work with other Debian-
 based distributions.
 
-This module requires the `puppetlabs-apt` module in order to manage Apt repos.
+This module requires the `puppetlabs-apt` module in order to manage
+Apt repos (if `manage_repo` is true).
 
 ### Beginning with flatpak
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,3 @@
+---
+flatpak::package_ensure: 'installed'
+flatpak::manage_repo: false

--- a/data/os/family/Debian.yaml
+++ b/data/os/family/Debian.yaml
@@ -1,0 +1,2 @@
+---
+flatpak::manage_repo: true

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,13 @@
+---
+version: 5
+
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
+hierarchy:
+  - name: 'OS Family'
+    path: 'os/family/%{facts.os.family}.yaml'
+
+  - name: 'common'
+    path: 'common.yaml'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,8 +57,6 @@ class flatpak (
   Boolean $manage_repo = true,
   Optional[String] $repo_file_name = undef,
 ){
-  include ::apt
-
   # If Facter is at least 3.0.0
   if versioncmp($::facterversion, '3.0.0') >= 0 {
     $dist_codename = $::os['distro']['codename']
@@ -71,6 +69,8 @@ class flatpak (
   }
 
   if $manage_repo {
+    include ::apt
+
     if $repo_file_name {
       $repo_name = $repo_file_name
     } else {
@@ -86,6 +86,8 @@ class flatpak (
         server => 'keyserver.ubuntu.com',
       },
     }
+
+    Exec['apt_update'] -> Package['flatpak']
   }
 
   package { 'flatpak':
@@ -93,8 +95,6 @@ class flatpak (
   }
 
   Flatpak_remote <| |> -> Flatpak <| |>
-
-  Exec['apt_update'] -> Package['flatpak']
 }
 
 # vim: ts=2 sts=2 sw=2 expandtab

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,8 +11,9 @@
 # version. Defaults to 'installed'.
 #
 # * `manage_repo`
-# Wether we should manage the apt repo or assume that flatpak is
-# available from packaging. Defaults to 'true'.
+# Wether to manage the apt repo or assume it is provided by another repo managed
+# elsewhere. Defaults to 'true' on Debian-based systems. (Only apt is presently
+# supported)
 #
 # * `repo_file_name`
 # Optional name for the repo source file. Defaults to the PPA naming scheme to
@@ -35,7 +36,7 @@
 # Copyright
 # ---------
 #
-# Copyright 2017 Bryan Wyatt, unless otherwise noted.
+# Copyright 2017, 2020 Bryan Wyatt, unless otherwise noted.
 #
 # This file is part of brwyatt-flatpak.
 #
@@ -53,8 +54,8 @@
 # along with brwyatt-flatpak.  If not, see <http://www.gnu.org/licenses/>.
 
 class flatpak (
-  String $package_ensure = 'installed',
-  Boolean $manage_repo = true,
+  String $package_ensure,
+  Boolean $manage_repo,
   Optional[String] $repo_file_name = undef,
 ){
   # If Facter is at least 3.0.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,19 +58,20 @@ class flatpak (
   Boolean $manage_repo,
   Optional[String] $repo_file_name = undef,
 ){
-  # If Facter is at least 3.0.0
-  if versioncmp($::facterversion, '3.0.0') >= 0 {
-    $dist_codename = $::os['distro']['codename']
-  } elsif versioncmp($::facterversion, '2.2.0') >= 0 {
-    # Version is at least 2.2.0
-    $dist_codename = $::os['lsb']['distcodename']
-  } else {
-    # REALLY old version, use legacy fact
-    $dist_codename = $::lsbdistcodename
-  }
 
   if $manage_repo {
     include ::apt
+
+    if versioncmp($::facterversion, '3.0.0') >= 0 {
+      # If Facter is at least 3.0.0
+      $dist_codename = $::os['distro']['codename']
+    } elsif versioncmp($::facterversion, '2.2.0') >= 0 {
+      # Version is at least 2.2.0
+      $dist_codename = $::os['lsb']['distcodename']
+    } else {
+      # REALLY old version, use legacy fact
+      $dist_codename = $::lsbdistcodename
+    }
 
     if $repo_file_name {
       $repo_name = $repo_file_name

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,10 @@
 # Ensure value for the Flatpack package. Should be 'installed', 'latest', or a
 # version. Defaults to 'installed'.
 #
+# * `manage_repo`
+# Wether we should manage the apt repo or assume that flatpak is
+# available from packaging. Defaults to 'true'.
+#
 # * `repo_file_name`
 # Optional name for the repo source file. Defaults to the PPA naming scheme to
 # avoid duplicate repository files.
@@ -50,6 +54,7 @@
 
 class flatpak (
   String $package_ensure = 'installed',
+  Boolean $manage_repo = true,
   Optional[String] $repo_file_name = undef,
 ){
   include ::apt
@@ -65,20 +70,22 @@ class flatpak (
     $dist_codename = $::lsbdistcodename
   }
 
-  if $repo_file_name {
-    $repo_name = $repo_file_name
-  } else {
-    $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
-  }
+  if $manage_repo {
+    if $repo_file_name {
+      $repo_name = $repo_file_name
+    } else {
+      $repo_name = "alexlarsson-ubuntu-flatpak-${dist_codename}"
+    }
 
-  apt::source { $repo_name:
-    location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
-    release  => $dist_codename,
-    repos    => 'main',
-    key      => {
-      id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',
-      server => 'keyserver.ubuntu.com',
-    },
+    apt::source { $repo_name:
+      location => 'http://ppa.launchpad.net/alexlarsson/flatpak/ubuntu',
+      release  => $dist_codename,
+      repos    => 'main',
+      key      => {
+        id     => '690951F1A4DE0F905496E8C6C793BFA2FA577F07',
+        server => 'keyserver.ubuntu.com',
+      },
+    }
   }
 
   package { 'flatpak':

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,22 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "7",
+        "8"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "brwyatt-flatpak",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "author": "Bryan Wyatt <brwyatt@gmail.com>",
   "summary": "Module for installing and managing Flatpak packages",
   "license": "LGPL-3.0",

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,10 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 7.0.0"
+    },
+    {
+      "name": "puppetlabs-apt",
+      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -11,10 +11,6 @@
     {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 4.0.0 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/flatpak_spec.rb
+++ b/spec/classes/flatpak_spec.rb
@@ -8,8 +8,8 @@ describe 'flatpak' do
       it { is_expected.to compile }
       it { is_expected.to contain_package('flatpak') }
 
-      if facts[:osfamily] == 'Debian' then
-      	it { is_expected.to contain_class('apt') }
+      if facts[:osfamily] == 'Debian'
+        it { is_expected.to contain_class('apt') }
 
         context 'with repo_file_name' do
           let(:params) { { 'repo_file_name' => 'TEST' } }
@@ -17,8 +17,8 @@ describe 'flatpak' do
           it { is_expected.to contain_apt__source('TEST') }
           it { is_expected.to contain_file('/etc/apt/sources.list.d/TEST.list') }
         end
-      elsif facts[:osfamily] == 'RedHat' then
-        it { is_expected.to_not contain_class('apt') }
+      elsif facts[:osfamily] == 'RedHat'
+        it { is_expected.not_to contain_class('apt') }
       end
     end
   end

--- a/spec/classes/flatpak_spec.rb
+++ b/spec/classes/flatpak_spec.rb
@@ -1,19 +1,24 @@
 require 'spec_helper'
 
 describe 'flatpak' do
-  on_supported_os(facterversion: '2.4').each do |os, os_facts|
+  on_supported_os(facterversion: '2.4').each do |os, facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      let(:facts) { facts }
 
       it { is_expected.to compile }
       it { is_expected.to contain_package('flatpak') }
-      it { is_expected.to contain_class('apt') }
 
-      context 'with repo_file_name' do
-        let(:params) { { 'repo_file_name' => 'TEST' } }
+      if facts[:osfamily] == 'Debian' then
+      	it { is_expected.to contain_class('apt') }
 
-        it { is_expected.to contain_apt__source('TEST') }
-        it { is_expected.to contain_file('/etc/apt/sources.list.d/TEST.list') }
+        context 'with repo_file_name' do
+          let(:params) { { 'repo_file_name' => 'TEST' } }
+
+          it { is_expected.to contain_apt__source('TEST') }
+          it { is_expected.to contain_file('/etc/apt/sources.list.d/TEST.list') }
+        end
+      elsif facts[:osfamily] == 'RedHat' then
+        it { is_expected.to_not contain_class('apt') }
       end
     end
   end


### PR DESCRIPTION
Building on top of #10, wanted to clean this up and make the support for RHEL a little more official.

In addition to @anarcat's changes, I've updated the tests and added in Hiera to automatically enable/disable repo management based on OS Family, and officially added CentOS/RHEL as supported, as per @traylenator's PR #8. I've also bumped the metadata.json version so when this is merged, a new version will get pushed to the Forge as well.

One final note: since the "dependencies" section is mostly just suggestions (and not checked or enforced at runtime), I've added the puppetlabs-apt dependency back in, so the version hints will remain. This shouldn't cause any issues for anyone not using (and not needing) the apt module (it shouldn't result in it getting installed, and even if it did, it shouldn't cause problems).