### PR TITLE
Added --gpg_import parameter for flatpak_remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ Parameters:
 * `name`: (namevar) The name of the remote
 * `location`: The location for the remote
 * `from`: if `true`, it specifies that location is a repo config file.
+* `gpg_import`: If defined, imports the gpg-file with the remote. The gpg file needs to exist already
+   and should probably be placed in /var/lib/flatpak/repo diretory.
 
 ### Providers
 

--- a/lib/puppet/provider/flatpak_remote/flatpak_remote.rb
+++ b/lib/puppet/provider/flatpak_remote/flatpak_remote.rb
@@ -23,6 +23,9 @@ Puppet::Type.type(:flatpak_remote).provide(:flatpak_remote) do
 
   def create
     args = ['remote-add']
+    if resource[:gpg_import]
+      args.push('--gpg-import=' + resource[:gpg_import])
+    end
     if resource[:from]
       args.push('--from')
     end

--- a/lib/puppet/type/flatpak_remote.rb
+++ b/lib/puppet/type/flatpak_remote.rb
@@ -47,6 +47,12 @@ Puppet::Type.newtype(:flatpak_remote) do
 
     defaultto false
   end
+
+  newparam(:gpg_import) do
+    desc 'Specify gpg file to import'
+
+    defaultto false
+  end
 end
 
 # vim: ts=2 sts=2 sw=2 expandtab


### PR DESCRIPTION
Flatpak warns about missing gpg signatures, this commit allows you to import a gpg file with the remote.