### PR TITLE
Check if repo is disabled when creating

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,37 +2,35 @@
 require: rubocop-rspec
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: "2.5"
   Include:
-  - "./**/*.rb"
+    - "./**/*.rb"
   Exclude:
-  - bin/*
-  - ".vendor/**/*"
-  - "**/Gemfile"
-  - "**/Rakefile"
-  - pkg/**/*
-  - spec/fixtures/**/*
-  - vendor/**/*
-  - "**/Puppetfile"
-  - "**/Vagrantfile"
-  - "**/Guardfile"
-Metrics/LineLength:
+    - bin/*
+    - ".vendor/**/*"
+    - "**/Gemfile"
+    - "**/Rakefile"
+    - pkg/**/*
+    - spec/fixtures/**/*
+    - vendor/**/*
+    - "**/Puppetfile"
+    - "**/Vagrantfile"
+    - "**/Guardfile"
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/*
 RSpec/BeforeAfterAll:
-  Description: Beware of using after(:all) as it may cause state to leak between tests.
+  Description:
+    Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
   Exclude:
-  - spec/acceptance/**/*.rb
+    - spec/acceptance/**/*.rb
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
 Style/BlockDelimiters:
-  Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
+  Description:
+    Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
 Style/ClassAndModuleChildren:
@@ -45,7 +43,8 @@ Style/FormatString:
   Description: Following the main puppet project's style, prefer the % format format.
   EnforcedStyle: percent
 Style/FormatStringToken:
-  Description: Following the main puppet project's style, prefer the simpler template
+  Description:
+    Following the main puppet project's style, prefer the simpler template
     tokens over annotated ones.
   EnforcedStyle: template
 Style/Lambda:
@@ -55,16 +54,19 @@ Style/RegexpLiteral:
   Description: Community preference. See https://github.com/voxpupuli/modulesync_config/issues/168
   EnforcedStyle: percent_r
 Style/TernaryParentheses:
-  Description: Checks for use of parentheses around ternary conditions. Enforce parentheses
+  Description:
+    Checks for use of parentheses around ternary conditions. Enforce parentheses
     on complex expressions for better readability, but seriously consider breaking
     it up.
   EnforcedStyle: require_parentheses_when_complex
 Style/TrailingCommaInArguments:
-  Description: Prefer always trailing comma on multiline argument lists. This makes
+  Description:
+    Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
-  Description: Prefer always trailing comma on multiline literals. This makes diffs,
+Style/TrailingCommaInArrayLiteral:
+  Description:
+    Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
 Style/SymbolArray:
@@ -74,8 +76,8 @@ RSpec/MessageSpies:
   EnforcedStyle: receive
 Style/Documentation:
   Exclude:
-  - lib/puppet/parser/functions/**/*
-  - spec/**/*
+    - lib/puppet/parser/functions/**/*
+    - spec/**/*
 Style/WordArray:
   EnforcedStyle: brackets
 Style/CollectionMethods:
@@ -86,7 +88,7 @@ Style/StringMethods:
   Enabled: true
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 9.0.0"
+      "version_requirement": ">= 4.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.0.0 < 9.0.0"
+      "version_requirement": ">= 4.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 4.0.0 < 9.0.0"
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
A flatpak repo can be disabled (default setup on Fedora for flathub). In
that case, we simply enable it.

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>